### PR TITLE
Rename PDOStatement.execute() to PDOStatement.bindAndExecute()

### DIFF
--- a/includes/Http/Controllers/Api/Server/UserServiceCollection.php
+++ b/includes/Http/Controllers/Api/Server/UserServiceCollection.php
@@ -36,7 +36,7 @@ AND (
 ORDER BY us.id DESC
 EOF
         );
-        $statement->execute([
+        $statement->bindAndExecute([
             $serverId,
             ExtraFlagType::TYPE_NICK,
             $nick,

--- a/includes/Http/Services/IncomeService.php
+++ b/includes/Http/Services/IncomeService.php
@@ -29,7 +29,7 @@ class IncomeService
                 "WHERE t.free = '0' AND IFNULL(t.income,'') != '' AND t.payment != 'wallet' AND t.timestamp LIKE ? " .
                 "ORDER BY t.timestamp ASC"
         );
-        $statement->execute(["$year-$month-%"]);
+        $statement->bindAndExecute(["$year-$month-%"]);
 
         // Let's sum income by date (day precision) and server
         $data = [];

--- a/includes/Install/DatabaseMigration.php
+++ b/includes/Install/DatabaseMigration.php
@@ -65,11 +65,11 @@ class DatabaseMigration
 
         $this->db
             ->statement("UPDATE `ss_settings` SET `value`= ? WHERE `key` = 'random_key'")
-            ->execute([get_random_string(16)]);
+            ->bindAndExecute([get_random_string(16)]);
 
         $this->db
             ->statement("UPDATE `ss_settings` SET `value` = ? WHERE `key` = 'license_token'")
-            ->execute([$licenseToken]);
+            ->bindAndExecute([$licenseToken]);
 
         $this->db
             ->statement(
@@ -86,7 +86,7 @@ SET
 `billing_address` = '{}'
 EOF
             )
-            ->execute([
+            ->bindAndExecute([
                 $adminUsername,
                 $adminEmail,
                 hash_password($adminPassword, $salt),
@@ -134,7 +134,7 @@ EOF
 
     private function saveExecutedMigration($name): void
     {
-        $this->db->statement("INSERT INTO `ss_migrations` SET `name` = ?")->execute([$name]);
+        $this->db->statement("INSERT INTO `ss_migrations` SET `name` = ?")->bindAndExecute([$name]);
     }
 
     /**

--- a/includes/Payment/Admin/AdminPaymentService.php
+++ b/includes/Payment/Admin/AdminPaymentService.php
@@ -23,7 +23,7 @@ class AdminPaymentService
     {
         $this->db
             ->statement("INSERT INTO `ss_payment_admin` (`aid`, `ip`, `platform`) VALUES (?, ?, ?)")
-            ->execute([$admin->getId(), $ip, $platform]);
+            ->bindAndExecute([$admin->getId(), $ip, $platform]);
 
         return $this->db->lastId();
     }

--- a/includes/Payment/General/PurchaseInformation.php
+++ b/includes/Payment/General/PurchaseInformation.php
@@ -51,7 +51,7 @@ class PurchaseInformation
         $statement = $this->db->statement(
             "SELECT * FROM ({$this->transactionRepository->getQuery()}) as t WHERE {$queryParticle}"
         );
-        $statement->execute($queryParticle->params());
+        $statement->bindAndExecute($queryParticle->params());
 
         if (!$statement->rowCount()) {
             return "";

--- a/includes/Payment/Sms/SmsPaymentService.php
+++ b/includes/Payment/Sms/SmsPaymentService.php
@@ -140,7 +140,7 @@ class SmsPaymentService
                 "INSERT INTO `ss_payment_sms` (`code`, `income`, `cost`, `text`, `number`, `ip`, `platform`, `free`) " .
                     "VALUES (?,?,?,?,?,?,?,?)"
             )
-            ->execute([
+            ->bindAndExecute([
                 $code,
                 $this->smsPriceService->getProvision($price, $smsPaymentModule)->asInt(),
                 $this->smsPriceService->getGross($price)->asInt(),

--- a/includes/Payment/Sms/SmsServiceTakeOver.php
+++ b/includes/Payment/Sms/SmsServiceTakeOver.php
@@ -22,7 +22,7 @@ class SmsServiceTakeOver implements IServiceTakeOver
             "SELECT * FROM ({$this->transactionRepository->getQuery()}) as t " .
                 "WHERE t.payment = 'sms' AND t.sms_code = ? AND `service_id` = ? AND `server_id` = ? AND `auth_data` = ?"
         );
-        $statement->execute([$paymentId, $serviceId, $serverId, $authData]);
+        $statement->bindAndExecute([$paymentId, $serviceId, $serverId, $authData]);
 
         return !!$statement->rowCount();
     }

--- a/includes/Payment/Transfer/TransferServiceTakeOver.php
+++ b/includes/Payment/Transfer/TransferServiceTakeOver.php
@@ -22,7 +22,7 @@ class TransferServiceTakeOver implements IServiceTakeOver
             "SELECT * FROM ({$this->transactionRepository->getQuery()}) as t " .
                 "WHERE t.payment = 'transfer' AND t.payment_id = ? AND `service_id` = ? AND `server_id` = ? AND `auth_data` = ?"
         );
-        $statement->execute([$paymentId, $serviceId, $serverId, $authData]);
+        $statement->bindAndExecute([$paymentId, $serviceId, $serverId, $authData]);
 
         return !!$statement->rowCount();
     }

--- a/includes/Payment/Wallet/WalletPaymentService.php
+++ b/includes/Payment/Wallet/WalletPaymentService.php
@@ -32,7 +32,7 @@ class WalletPaymentService
 
         $this->db
             ->statement("INSERT INTO `ss_payment_wallet` SET `cost` = ?, `ip` = ?, `platform` = ?")
-            ->execute([$cost->asInt(), $ip, $platform]);
+            ->bindAndExecute([$cost->asInt(), $ip, $platform]);
 
         return $this->db->lastId();
     }
@@ -45,7 +45,7 @@ class WalletPaymentService
     {
         $this->db
             ->statement("UPDATE `ss_users` SET `wallet` = `wallet` + ? WHERE `uid` = ?")
-            ->execute([$quantity, $user->getId()]);
+            ->bindAndExecute([$quantity, $user->getId()]);
 
         $user->setWallet($user->getWallet()->add($quantity));
     }

--- a/includes/Repositories/BoughtServiceRepository.php
+++ b/includes/Repositories/BoughtServiceRepository.php
@@ -17,7 +17,7 @@ class BoughtServiceRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_bought_services` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -58,7 +58,7 @@ SET
     `extra_data` = ?
 EOF
             )
-            ->execute([
+            ->bindAndExecute([
                 $userId ?: 0,
                 $method,
                 $paymentId,

--- a/includes/Repositories/GroupRepository.php
+++ b/includes/Repositories/GroupRepository.php
@@ -39,7 +39,7 @@ class GroupRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_groups` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -56,7 +56,7 @@ class GroupRepository
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_groups` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
         return !!$statement->rowCount();
     }
 
@@ -70,7 +70,7 @@ class GroupRepository
         $statement = $this->db->statement(
             "INSERT INTO `ss_groups` SET `name` = ?, `permissions` = ?"
         );
-        $statement->execute([$name, implode(",", $permissions)]);
+        $statement->bindAndExecute([$name, implode(",", $permissions)]);
         return $this->get($this->db->lastId());
     }
 
@@ -85,7 +85,7 @@ class GroupRepository
         $statement = $this->db->statement(
             "UPDATE `ss_groups` SET `name` = ?, `permissions` = ? WHERE `id` = ?"
         );
-        $statement->execute([$name, implode(",", $permissions), $id]);
+        $statement->bindAndExecute([$name, implode(",", $permissions), $id]);
         return !!$statement->rowCount();
     }
 

--- a/includes/Repositories/LogRepository.php
+++ b/includes/Repositories/LogRepository.php
@@ -15,7 +15,7 @@ class LogRepository
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_logs` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
 
         return !!$statement->rowCount();
     }
@@ -26,7 +26,7 @@ class LogRepository
      */
     public function create($message): int
     {
-        $this->db->statement("INSERT INTO `ss_logs` SET `text` = ?")->execute([$message]);
+        $this->db->statement("INSERT INTO `ss_logs` SET `text` = ?")->bindAndExecute([$message]);
         return $this->db->lastId();
     }
 }

--- a/includes/Repositories/PaymentDirectBillingRepository.php
+++ b/includes/Repositories/PaymentDirectBillingRepository.php
@@ -20,7 +20,7 @@ class PaymentDirectBillingRepository
             $statement = $this->db->statement(
                 "SELECT * FROM `ss_payment_direct_billing` WHERE `id` = ?"
             );
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -36,7 +36,7 @@ class PaymentDirectBillingRepository
             $statement = $this->db->statement(
                 "SELECT * FROM `ss_payment_direct_billing` WHERE `external_id` = ?"
             );
-            $statement->execute([$externalId]);
+            $statement->bindAndExecute([$externalId]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -53,7 +53,7 @@ class PaymentDirectBillingRepository
                 "INSERT INTO `ss_payment_direct_billing` " .
                     "SET `external_id` = ?, `income` = ?, `cost` = ?, `ip` = ?, `platform` = ?, `free` = ?"
             )
-            ->execute([$externalId, $income, $cost, $ip, $platform, $free ? 1 : 0]);
+            ->bindAndExecute([$externalId, $income, $cost, $ip, $platform, $free ? 1 : 0]);
 
         return $this->get($this->db->lastId());
     }

--- a/includes/Repositories/PaymentPlatformRepository.php
+++ b/includes/Repositories/PaymentPlatformRepository.php
@@ -26,7 +26,7 @@ class PaymentPlatformRepository
             ->statement(
                 "INSERT INTO `ss_payment_platforms` SET `name` = ?, `module` = ?, `data` = ?"
             )
-            ->execute([$name, $module, json_encode($data)]);
+            ->bindAndExecute([$name, $module, json_encode($data)]);
 
         return $this->get($this->db->lastId());
     }
@@ -40,7 +40,7 @@ class PaymentPlatformRepository
     {
         $this->db
             ->statement("UPDATE `ss_payment_platforms` SET `name` = ?, `data` = ? WHERE `id` = ?")
-            ->execute([$name, json_encode($data), $id]);
+            ->bindAndExecute([$name, json_encode($data), $id]);
     }
 
     /**
@@ -65,7 +65,7 @@ class PaymentPlatformRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_payment_platforms` WHERE `id` IN ({$keys})"
         );
-        $statement->execute($ids);
+        $statement->bindAndExecute($ids);
 
         return collect($statement)
             ->map(fn(array $row) => $this->mapToModel($row))
@@ -82,7 +82,7 @@ class PaymentPlatformRepository
             $statement = $this->db->statement(
                 "SELECT * FROM `ss_payment_platforms` WHERE `id` = ?"
             );
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -113,7 +113,7 @@ class PaymentPlatformRepository
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_payment_platforms` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
         return !!$statement->rowCount();
     }
 

--- a/includes/Repositories/PaymentTransferRepository.php
+++ b/includes/Repositories/PaymentTransferRepository.php
@@ -42,7 +42,15 @@ class PaymentTransferRepository
                 "INSERT INTO `ss_payment_transfer` " .
                     "SET `id` = ?, `income` = ?, `cost` = ?, `transfer_service` = ?, `ip` = ?, `platform` = ?, `free` = ? "
             )
-            ->bindAndExecute([$id, $income, $cost, $transferService, $ip, $platform, $free ? 1 : 0]);
+            ->bindAndExecute([
+                $id,
+                $income,
+                $cost,
+                $transferService,
+                $ip,
+                $platform,
+                $free ? 1 : 0,
+            ]);
 
         return $this->get($id);
     }

--- a/includes/Repositories/PaymentTransferRepository.php
+++ b/includes/Repositories/PaymentTransferRepository.php
@@ -18,7 +18,7 @@ class PaymentTransferRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_payment_transfer` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -42,7 +42,7 @@ class PaymentTransferRepository
                 "INSERT INTO `ss_payment_transfer` " .
                     "SET `id` = ?, `income` = ?, `cost` = ?, `transfer_service` = ?, `ip` = ?, `platform` = ?, `free` = ? "
             )
-            ->execute([$id, $income, $cost, $transferService, $ip, $platform, $free ? 1 : 0]);
+            ->bindAndExecute([$id, $income, $cost, $transferService, $ip, $platform, $free ? 1 : 0]);
 
         return $this->get($id);
     }

--- a/includes/Repositories/PriceRepository.php
+++ b/includes/Repositories/PriceRepository.php
@@ -20,7 +20,7 @@ class PriceRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_prices` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -53,7 +53,7 @@ class PriceRepository
                 "INSERT INTO `ss_prices` (`service_id`, `server_id`, `sms_price`, `transfer_price`, `direct_billing_price`, `quantity`, `discount`) " .
                     "VALUES ( ?, ?, ?, ?, ?, ?, ? )"
             )
-            ->execute([
+            ->bindAndExecute([
                 $serviceId,
                 $serverId,
                 $smsPrice,
@@ -78,7 +78,7 @@ class PriceRepository
                 "WHERE `service_id` = ? AND (`server_id` = ? OR `server_id` IS NULL) " .
                 "ORDER BY `quantity` ASC"
         );
-        $statement->execute([$service->getId(), $server ? $server->getId() : null]);
+        $statement->bindAndExecute([$service->getId(), $server ? $server->getId() : null]);
 
         $prices = [];
         foreach ($statement as $row) {
@@ -112,7 +112,7 @@ class PriceRepository
             WHERE `id` = ?
 EOF
         );
-        $statement->execute([
+        $statement->bindAndExecute([
             $serviceId,
             $serverId,
             $smsPrice,
@@ -129,7 +129,7 @@ EOF
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_prices` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
 
         return !!$statement->rowCount();
     }

--- a/includes/Repositories/PromoCodeRepository.php
+++ b/includes/Repositories/PromoCodeRepository.php
@@ -40,7 +40,7 @@ SET
 `user_id` = ?
 EOF
             )
-            ->execute([
+            ->bindAndExecute([
                 $code,
                 $quantityType,
                 $quantity,
@@ -62,7 +62,7 @@ EOF
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_promo_codes` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -80,7 +80,7 @@ EOF
     {
         if (strlen($code)) {
             $statement = $this->db->statement("SELECT * FROM `ss_promo_codes` WHERE `code` = ?");
-            $statement->execute([$code]);
+            $statement->bindAndExecute([$code]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -97,7 +97,7 @@ EOF
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_promo_codes` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
 
         return !!$statement->rowCount();
     }
@@ -111,7 +111,7 @@ EOF
             ->statement(
                 "UPDATE `ss_promo_codes` SET `usage_count` = `usage_count` + 1 WHERE `id` = ?"
             )
-            ->execute([$id]);
+            ->bindAndExecute([$id]);
     }
 
     public function mapToModel(array $data): PromoCode

--- a/includes/Repositories/ServerRepository.php
+++ b/includes/Repositories/ServerRepository.php
@@ -87,7 +87,14 @@ class ServerRepository
                     "SET `name` = ?, `ip` = ?, `port` = ?, `sms_platform` = ?, `transfer_platform` = ? " .
                     "WHERE `id` = ?"
             )
-            ->bindAndExecute([$name, $ip, $port, $smsPlatformId, implode(",", $transferPlatformIds), $id]);
+            ->bindAndExecute([
+                $name,
+                $ip,
+                $port,
+                $smsPlatformId,
+                implode(",", $transferPlatformIds),
+                $id,
+            ]);
     }
 
     public function delete($id): bool

--- a/includes/Repositories/ServerRepository.php
+++ b/includes/Repositories/ServerRepository.php
@@ -37,7 +37,7 @@ class ServerRepository
             $statement = $this->db->statement(
                 "SELECT *, UNIX_TIMESTAMP(`last_active_at`) FROM `ss_servers` WHERE `id` = ?"
             );
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -52,7 +52,7 @@ class ServerRepository
         $statement = $this->db->statement(
             "SELECT *, UNIX_TIMESTAMP(`last_active_at`) FROM `ss_servers` WHERE `token` = ?"
         );
-        $statement->execute([$token]);
+        $statement->bindAndExecute([$token]);
         $data = $statement->fetch();
 
         return $data ? $this->mapToModel($data) : null;
@@ -67,7 +67,7 @@ class ServerRepository
                 "INSERT INTO `ss_servers` " .
                     "SET `name` = ?, `ip` = ?, `port` = ?, `sms_platform` = ?, `transfer_platform` = ?, `token` = ?"
             )
-            ->execute([
+            ->bindAndExecute([
                 $name,
                 $ip,
                 $port,
@@ -87,13 +87,13 @@ class ServerRepository
                     "SET `name` = ?, `ip` = ?, `port` = ?, `sms_platform` = ?, `transfer_platform` = ? " .
                     "WHERE `id` = ?"
             )
-            ->execute([$name, $ip, $port, $smsPlatformId, implode(",", $transferPlatformIds), $id]);
+            ->bindAndExecute([$name, $ip, $port, $smsPlatformId, implode(",", $transferPlatformIds), $id]);
     }
 
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_servers` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
 
         return !!$statement->rowCount();
     }
@@ -104,7 +104,7 @@ class ServerRepository
             ->statement(
                 "UPDATE `ss_servers` SET `type` = ?, `version` = ?, `last_active_at` = NOW() WHERE `id` = ?"
             )
-            ->execute([$type, $version, $id]);
+            ->bindAndExecute([$type, $version, $id]);
     }
 
     /**
@@ -117,7 +117,7 @@ class ServerRepository
 
         $this->db
             ->statement("UPDATE `ss_servers` SET `token` = ? WHERE `id` = ?")
-            ->execute([$token, $id]);
+            ->bindAndExecute([$token, $id]);
 
         return $token;
     }

--- a/includes/Repositories/ServerServiceRepository.php
+++ b/includes/Repositories/ServerServiceRepository.php
@@ -29,7 +29,7 @@ class ServerServiceRepository
     {
         $this->db
             ->statement("INSERT INTO `ss_servers_services` SET `server_id` = ?, `service_id` = ?")
-            ->execute([$serverId, $serviceId]);
+            ->bindAndExecute([$serverId, $serviceId]);
 
         return $this->mapToModel([
             "server_id" => $serverId,
@@ -46,7 +46,7 @@ class ServerServiceRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_servers_services` WHERE `server_id` = ?"
         );
-        $statement->execute([$serverId]);
+        $statement->bindAndExecute([$serverId]);
 
         return collect($statement)
             ->map(fn(array $row) => $this->mapToModel($row))
@@ -62,7 +62,7 @@ class ServerServiceRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_servers_services` WHERE `service_id` = ?"
         );
-        $statement->execute([$serviceId]);
+        $statement->bindAndExecute([$serviceId]);
 
         return collect($statement)
             ->map(fn(array $row) => $this->mapToModel($row))

--- a/includes/Repositories/ServiceRepository.php
+++ b/includes/Repositories/ServiceRepository.php
@@ -29,7 +29,7 @@ class ServiceRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_services` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -53,7 +53,7 @@ class ServiceRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_services` WHERE `id` IN ({$keys}) ORDER BY `order` ASC"
         );
-        $statement->execute($ids);
+        $statement->bindAndExecute($ids);
 
         return collect($statement)
             ->map(fn(array $row) => $this->mapToModel($row))
@@ -79,7 +79,7 @@ class ServiceRepository
                     "SET `id` = ?, `name` = ?, `short_description` = ?, `description` = ?, `tag` = ?, " .
                     "`module` = ?, `groups` = ?, `order` = ?, `data` = ?, `types` = ?, `flags` = ?"
             )
-            ->execute([
+            ->bindAndExecute([
                 $id,
                 $name,
                 $shortDescription ?: "",
@@ -115,7 +115,7 @@ class ServiceRepository
                 "`groups` = ?, `order` = ?, `data` = ?, `types` = ?, `flags` = ? " .
                 "WHERE `id` = ?"
         );
-        $statement->execute([
+        $statement->bindAndExecute([
             $newId,
             $name,
             $shortDescription ?: "",
@@ -135,7 +135,7 @@ class ServiceRepository
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_services` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
 
         return !!$statement->rowCount();
     }

--- a/includes/Repositories/SettingsRepository.php
+++ b/includes/Repositories/SettingsRepository.php
@@ -42,7 +42,7 @@ class SettingsRepository
                 implode(", ", $keys) .
                 " )"
         );
-        $statement->execute($params);
+        $statement->bindAndExecute($params);
 
         return !!$statement->rowCount();
     }

--- a/includes/Repositories/SmsCodeRepository.php
+++ b/includes/Repositories/SmsCodeRepository.php
@@ -23,7 +23,7 @@ class SmsCodeRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_sms_codes` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -43,7 +43,7 @@ class SmsCodeRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_sms_codes` WHERE `code` = ? AND `sms_price` = ? AND (`expires_at` IS NULL OR `expires_at` > NOW())"
         );
-        $statement->execute([$code, $smsPrice->asInt()]);
+        $statement->bindAndExecute([$code, $smsPrice->asInt()]);
 
         if ($data = $statement->fetch()) {
             return $this->mapToModel($data);
@@ -65,7 +65,7 @@ class SmsCodeRepository
             ->statement(
                 "INSERT INTO `ss_sms_codes` SET `code` = ?, `sms_price` = ?, `free` = ?, `expires_at` = ?"
             )
-            ->execute([$code, $smsPrice->asInt(), $free ? 1 : 0, serialize_date($expires)]);
+            ->bindAndExecute([$code, $smsPrice->asInt(), $free ? 1 : 0, serialize_date($expires)]);
 
         return $this->get($this->db->lastId());
     }
@@ -77,7 +77,7 @@ class SmsCodeRepository
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_sms_codes` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
 
         return !!$statement->rowCount();
     }

--- a/includes/Repositories/UserRepository.php
+++ b/includes/Repositories/UserRepository.php
@@ -53,7 +53,7 @@ class UserRepository
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())
 EOF
             )
-            ->execute([
+            ->bindAndExecute([
                 (string) $username,
                 hash_password($password, $salt),
                 $salt,
@@ -87,7 +87,7 @@ EOF
                 WHERE `uid` = ?
 EOF
             )
-            ->execute([
+            ->bindAndExecute([
                 (string) $user->getUsername(),
                 (string) $user->getForename(),
                 (string) $user->getSurname(),
@@ -119,7 +119,7 @@ EOF
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_users` WHERE `uid` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -143,7 +143,7 @@ EOF
         $steamIdSuffix = preg_replace("/^STEAM_[01]/", "", $steamId);
 
         $statement = $this->db->statement("SELECT * FROM `ss_users` WHERE `steam_id` IN (?, ?)");
-        $statement->execute(["STEAM_0{$steamIdSuffix}", "STEAM_1{$steamIdSuffix}"]);
+        $statement->bindAndExecute(["STEAM_0{$steamIdSuffix}", "STEAM_1{$steamIdSuffix}"]);
 
         $data = $statement->fetch();
         return $data ? $this->mapToModel($data) : null;
@@ -160,7 +160,7 @@ EOF
         }
 
         $statement = $this->db->statement("SELECT * FROM `ss_users` WHERE `username` = ?");
-        $statement->execute([$username]);
+        $statement->bindAndExecute([$username]);
 
         $data = $statement->fetch();
         return $data ? $this->mapToModel($data) : null;
@@ -177,7 +177,7 @@ EOF
         }
 
         $statement = $this->db->statement("SELECT * FROM `ss_users` WHERE `email` = ?");
-        $statement->execute([$email]);
+        $statement->bindAndExecute([$email]);
 
         $data = $statement->fetch();
         return $data ? $this->mapToModel($data) : null;
@@ -198,7 +198,7 @@ EOF
             "SELECT * FROM `ss_users` " .
                 "WHERE (`username` = ? OR `email` = ?) AND `password` = md5(CONCAT(md5(?), md5(`salt`)))"
         );
-        $statement->execute([$emailOrUsername, $emailOrUsername, $password]);
+        $statement->bindAndExecute([$emailOrUsername, $emailOrUsername, $password]);
 
         $data = $statement->fetch();
         return $data ? $this->mapToModel($data) : null;
@@ -217,7 +217,7 @@ EOF
         $statement = $this->db->statement(
             "SELECT * FROM `ss_users` WHERE `reset_password_key` = ?"
         );
-        $statement->execute([$resetKey]);
+        $statement->bindAndExecute([$resetKey]);
 
         $data = $statement->fetch();
         return $data ? $this->mapToModel($data) : null;
@@ -228,7 +228,7 @@ EOF
         $key = get_random_string(32);
         $this->db
             ->statement("UPDATE `ss_users` SET `reset_password_key` = ? WHERE `uid` = ?")
-            ->execute([$key, $userId]);
+            ->bindAndExecute([$key, $userId]);
 
         return $key;
     }
@@ -246,20 +246,20 @@ EOF
             ->statement(
                 "UPDATE `ss_users` SET `password` = ?, `salt` = ?, `reset_password_key` = '' WHERE `uid` = ?"
             )
-            ->execute([hash_password($password, $salt), $salt, $userId]);
+            ->bindAndExecute([hash_password($password, $salt), $salt, $userId]);
     }
 
     public function touch(User $user): void
     {
         $this->db
             ->statement("UPDATE `ss_users` SET `lastactiv` = NOW(), `lastip` = ? WHERE `uid` = ?")
-            ->execute([$user->getLastIp(), $user->getId()]);
+            ->bindAndExecute([$user->getLastIp(), $user->getId()]);
     }
 
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_users` WHERE `uid` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
 
         return !!$statement->rowCount();
     }

--- a/includes/Repositories/UserServiceRepository.php
+++ b/includes/Repositories/UserServiceRepository.php
@@ -25,7 +25,7 @@ class UserServiceRepository
             "INSERT INTO `ss_user_service` (`service_id`, `expire`, `user_id`, `comment`) " .
                 "VALUES (?, IF(? IS NULL, '-1', UNIX_TIMESTAMP() + ?), ?, ?)"
         );
-        $statement->execute([$serviceId, $seconds, $seconds, $userId ?: 0, $comment ?: ""]);
+        $statement->bindAndExecute([$serviceId, $seconds, $seconds, $userId ?: 0, $comment ?: ""]);
         return $this->db->lastId();
     }
 
@@ -42,14 +42,14 @@ class UserServiceRepository
             "INSERT INTO `ss_user_service` (`service_id`, `expire`, `user_id`, `comment`) " .
                 "VALUES (?, ?, ?, ?)"
         );
-        $statement->execute([$serviceId, $expiresAt, $userId ?: 0, $comment ?: ""]);
+        $statement->bindAndExecute([$serviceId, $expiresAt, $userId ?: 0, $comment ?: ""]);
         return $this->db->lastId();
     }
 
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_user_service` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
         return !!$statement->rowCount();
     }
 
@@ -61,7 +61,7 @@ class UserServiceRepository
 
         $keys = implode(",", array_fill(0, count($ids), "?"));
         $statement = $this->db->statement("DELETE FROM `ss_user_service` WHERE `id` IN ({$keys})");
-        $statement->execute($ids);
+        $statement->bindAndExecute($ids);
 
         return !!$statement->rowCount();
     }
@@ -84,7 +84,7 @@ class UserServiceRepository
         $params = implode(", ", $params);
 
         $statement = $this->db->statement("UPDATE `ss_user_service` SET {$params} WHERE `id` = ?");
-        $statement->execute(array_merge($values, [$id]));
+        $statement->bindAndExecute(array_merge($values, [$id]));
 
         return $statement->rowCount();
     }
@@ -106,7 +106,7 @@ class UserServiceRepository
             $params = implode(", ", $params);
 
             $statement = $this->db->statement("UPDATE `$table` SET {$params} WHERE `us_id` = ?");
-            $statement->execute(array_merge($values, [$userServiceId]));
+            $statement->bindAndExecute(array_merge($values, [$userServiceId]));
             $affected = max($affected, $statement->rowCount());
         }
 
@@ -118,7 +118,7 @@ class UserServiceRepository
         $statement = $this->db->statement(
             "UPDATE `ss_user_service` SET `user_id` = ? WHERE `id` = ?"
         );
-        $statement->execute([$userId, $id]);
+        $statement->bindAndExecute([$userId, $id]);
 
         return !!$statement->rowCount();
     }

--- a/includes/Server/ServerDataService.php
+++ b/includes/Server/ServerDataService.php
@@ -54,7 +54,7 @@ class ServerDataService
                 "AND `service_id` IN ({$keys}) " .
                 "ORDER BY `service_id` ASC, `quantity` ASC"
         );
-        $statement->execute(array_merge([$server->getId()], $serviceIds));
+        $statement->bindAndExecute(array_merge([$server->getId()], $serviceIds));
 
         return collect($statement)
             ->map(fn(array $row) => $this->priceRepository->mapToModel($row))
@@ -116,7 +116,7 @@ WHERE s.id = ?
 ORDER BY f.auth_data, f.type DESC
 EOF
         );
-        $statement->execute([$serverId]);
+        $statement->bindAndExecute([$serverId]);
 
         return collect($statement)
             ->map(function (array $data) {

--- a/includes/Service/ServerServiceService.php
+++ b/includes/Service/ServerServiceService.php
@@ -29,7 +29,7 @@ class ServerServiceService
                     "INSERT IGNORE INTO `ss_servers_services` (`server_id`, `service_id`) " .
                         "VALUES {$keys}"
                 )
-                ->execute($values);
+                ->bindAndExecute($values);
         }
 
         if ($itemsToDelete->isPopulated()) {
@@ -43,7 +43,7 @@ class ServerServiceService
 
             $this->db
                 ->statement("DELETE FROM `ss_servers_services` WHERE {$keys}")
-                ->execute($values);
+                ->bindAndExecute($values);
         }
     }
 }

--- a/includes/Service/UserServiceService.php
+++ b/includes/Service/UserServiceService.php
@@ -45,7 +45,7 @@ class UserServiceService
                     $query .
                     " ORDER BY us.id DESC "
             );
-            $statement->execute($values);
+            $statement->bindAndExecute($values);
 
             foreach ($statement as $row) {
                 $userService = $serviceModule->mapToUserService($row);

--- a/includes/ServiceModules/ExtraFlags/ExtraFlagUserServiceRepository.php
+++ b/includes/ServiceModules/ExtraFlags/ExtraFlagUserServiceRepository.php
@@ -82,7 +82,14 @@ class ExtraFlagUserServiceRepository
             "INSERT INTO `$table` (`us_id`, `server_id`, `service_id`, `type`, `auth_data`, `password`) " .
                 "VALUES (?, ?, ?, ?, ?, ?)"
         );
-        $statement->bindAndExecute([$userServiceId, $serverId, $serviceId, $type, $authData, $password]);
+        $statement->bindAndExecute([
+            $userServiceId,
+            $serverId,
+            $serviceId,
+            $type,
+            $authData,
+            $password,
+        ]);
 
         return $this->get($userServiceId);
     }

--- a/includes/ServiceModules/ExtraFlags/ExtraFlagUserServiceRepository.php
+++ b/includes/ServiceModules/ExtraFlags/ExtraFlagUserServiceRepository.php
@@ -53,7 +53,7 @@ class ExtraFlagUserServiceRepository
                 "INNER JOIN `$table` AS m ON m.us_id = us.id " .
                 ($params ? "WHERE {$params}" : "")
         );
-        $statement->execute($values);
+        $statement->bindAndExecute($values);
 
         return collect($statement)
             ->map(fn(array $row) => $this->mapToModel($row))
@@ -82,7 +82,7 @@ class ExtraFlagUserServiceRepository
             "INSERT INTO `$table` (`us_id`, `server_id`, `service_id`, `type`, `auth_data`, `password`) " .
                 "VALUES (?, ?, ?, ?, ?, ?)"
         );
-        $statement->execute([$userServiceId, $serverId, $serviceId, $type, $authData, $password]);
+        $statement->bindAndExecute([$userServiceId, $serverId, $serviceId, $type, $authData, $password]);
 
         return $this->get($userServiceId);
     }
@@ -96,7 +96,7 @@ class ExtraFlagUserServiceRepository
                     "INNER JOIN `$table` AS m ON m.us_id = us.id " .
                     "WHERE `id` = ?"
             );
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -123,7 +123,7 @@ SET `password` = ?
 WHERE `server_id` = ? AND `type` = ? AND `auth_data` = ?
 EOF
             )
-            ->execute([$password, $serverId, $type, $authData]);
+            ->bindAndExecute([$password, $serverId, $type, $authData]);
     }
 
     public function mapToModel(array $data): ExtraFlagUserService

--- a/includes/ServiceModules/ExtraFlags/ExtraFlagsServiceModule.php
+++ b/includes/ServiceModules/ExtraFlags/ExtraFlagsServiceModule.php
@@ -270,7 +270,7 @@ class ExtraFlagsServiceModule extends ServiceModule implements
             LIMIT ?, ?
 EOF
         );
-        $statement->execute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)
@@ -981,7 +981,7 @@ EOF
                 "INNER JOIN `{$this->getUserServiceTable()}` AS usef ON us.id = usef.us_id " .
                 "WHERE us.service_id = ? AND `server_id` = ? AND `type` = ? AND `auth_data` = ? AND `id` != ?"
         );
-        $statement->execute([
+        $statement->bindAndExecute([
             $this->service->getId(),
             $serverId,
             $type,
@@ -1043,7 +1043,7 @@ EOF
                         "SET `password` = ? " .
                         "WHERE `server_id` = ? AND `type` = ? AND `auth_data` = ?"
                 )
-                ->execute([$password, $serverId, $type, $authData]);
+                ->bindAndExecute([$password, $serverId, $type, $authData]);
         }
 
         // Only recalculate flags when something has changed
@@ -1124,7 +1124,7 @@ EOF
                 "INNER JOIN `{$this->getUserServiceTable()}` AS usef ON us.id = usef.us_id " .
                 "WHERE us.service_id = ? AND `server_id` = ? AND `type` = ? AND `auth_data` = ? AND `password` = ?"
         );
-        $statement->execute([$this->service->getId(), $serverId, $type, $authData, $password]);
+        $statement->bindAndExecute([$this->service->getId(), $serverId, $type, $authData, $password]);
 
         if (!$statement->rowCount()) {
             return [

--- a/includes/ServiceModules/ExtraFlags/ExtraFlagsServiceModule.php
+++ b/includes/ServiceModules/ExtraFlags/ExtraFlagsServiceModule.php
@@ -270,7 +270,9 @@ class ExtraFlagsServiceModule extends ServiceModule implements
             LIMIT ?, ?
 EOF
         );
-        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(
+            array_merge($queryParticle->params(), $pagination->getSqlLimit())
+        );
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)
@@ -1124,7 +1126,13 @@ EOF
                 "INNER JOIN `{$this->getUserServiceTable()}` AS usef ON us.id = usef.us_id " .
                 "WHERE us.service_id = ? AND `server_id` = ? AND `type` = ? AND `auth_data` = ? AND `password` = ?"
         );
-        $statement->bindAndExecute([$this->service->getId(), $serverId, $type, $authData, $password]);
+        $statement->bindAndExecute([
+            $this->service->getId(),
+            $serverId,
+            $type,
+            $authData,
+            $password,
+        ]);
 
         if (!$statement->rowCount()) {
             return [

--- a/includes/ServiceModules/ExtraFlags/PlayerFlagRepository.php
+++ b/includes/ServiceModules/ExtraFlags/PlayerFlagRepository.php
@@ -26,7 +26,7 @@ class PlayerFlagRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_players_flags` " . ($params ? "WHERE {$params}" : "")
         );
-        $statement->execute($values);
+        $statement->bindAndExecute($values);
 
         $data = $statement->fetch();
         if (!$data) {
@@ -44,7 +44,7 @@ class PlayerFlagRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_players_flags` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -59,7 +59,7 @@ class PlayerFlagRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_players_flags` WHERE `server_id` = ? AND `type` = ? AND `auth_data` = ?"
         );
-        $statement->execute([$serverId, $type, $authData]);
+        $statement->bindAndExecute([$serverId, $type, $authData]);
 
         if ($data = $statement->fetch()) {
             return $this->mapToModel($data);
@@ -92,7 +92,7 @@ class PlayerFlagRepository
             ->statement(
                 "INSERT INTO `ss_players_flags` SET `server_id` = ?, `type` = ?, `auth_data` = ?, `password` = ? {$keys}"
             )
-            ->execute(array_merge([$serverId, $type, $authData, $password], $values));
+            ->bindAndExecute(array_merge([$serverId, $type, $authData, $password], $values));
 
         return $this->get($this->db->lastId());
     }
@@ -104,7 +104,7 @@ class PlayerFlagRepository
                 "DELETE FROM `ss_players_flags` " .
                     "WHERE `server_id` = ? AND `type` = ? AND `auth_data` = ?"
             )
-            ->execute([$serverId, $type, $authData]);
+            ->bindAndExecute([$serverId, $type, $authData]);
     }
 
     public function deleteOldFlags(): void

--- a/includes/ServiceModules/ExtraFlags/Rules/ExtraFlagPasswordDiffersRule.php
+++ b/includes/ServiceModules/ExtraFlags/Rules/ExtraFlagPasswordDiffersRule.php
@@ -27,7 +27,7 @@ class ExtraFlagPasswordDiffersRule extends BaseRule
             "SELECT `password` FROM `$table` " .
                 "WHERE `type` = ? AND `auth_data` = ? AND `server_id` = ?"
         );
-        $statement->execute([$type, $authData, $serverId]);
+        $statement->bindAndExecute([$type, $authData, $serverId]);
         $existingPassword = $statement->fetchColumn();
 
         if ($existingPassword && $existingPassword !== $value) {

--- a/includes/ServiceModules/MybbExtraGroups/MybbExtraGroupsServiceModule.php
+++ b/includes/ServiceModules/MybbExtraGroups/MybbExtraGroupsServiceModule.php
@@ -254,7 +254,7 @@ ORDER BY us.id DESC
 LIMIT ?, ?
 EOF
         );
-        $statement->execute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)
@@ -494,7 +494,7 @@ EOF
                 "INNER JOIN `ss_services` AS s ON us.service_id = s.id " .
                 "WHERE m.mybb_uid = ?"
         );
-        $statement->execute([$userService->getMybbUid()]);
+        $statement->bindAndExecute([$userService->getMybbUid()]);
 
         foreach ($statement as $row) {
             $row["extra_data"] = json_decode($row["extra_data"], true);

--- a/includes/ServiceModules/MybbExtraGroups/MybbExtraGroupsServiceModule.php
+++ b/includes/ServiceModules/MybbExtraGroups/MybbExtraGroupsServiceModule.php
@@ -254,7 +254,9 @@ ORDER BY us.id DESC
 LIMIT ?, ?
 EOF
         );
-        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(
+            array_merge($queryParticle->params(), $pagination->getSqlLimit())
+        );
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/ServiceModules/MybbExtraGroups/MybbRepository.php
+++ b/includes/ServiceModules/MybbExtraGroups/MybbRepository.php
@@ -22,7 +22,7 @@ class MybbRepository
         $statement = $this->dbMybb()->statement(
             "SELECT `username` FROM `mybb_users` WHERE `uid` = ?"
         );
-        $statement->execute([$uid]);
+        $statement->bindAndExecute([$uid]);
         return $statement->fetchColumn();
     }
 
@@ -37,7 +37,7 @@ class MybbRepository
                 "FROM `mybb_users` " .
                 "WHERE `uid` = ?"
         );
-        $statement->execute([$uid]);
+        $statement->bindAndExecute([$uid]);
         return $statement->fetch();
     }
 
@@ -52,7 +52,7 @@ class MybbRepository
                 "FROM `mybb_users` " .
                 "WHERE `username` = ?"
         );
-        $statement->execute([$username]);
+        $statement->bindAndExecute([$username]);
         return $statement->fetch();
     }
 
@@ -63,7 +63,7 @@ class MybbRepository
     public function existsByUsername($username)
     {
         $statement = $this->dbMybb()->statement("SELECT 1 FROM `mybb_users` WHERE `username` = ?");
-        $statement->execute([$username]);
+        $statement->bindAndExecute([$username]);
         return $statement->rowCount() > 0;
     }
 
@@ -80,7 +80,7 @@ class MybbRepository
                     "SET `additionalgroups` = ?, `displaygroup` = ? " .
                     "WHERE `uid` = ?"
             )
-            ->execute([implode(",", $additionalGroups), $displayGroup, $uid]);
+            ->bindAndExecute([implode(",", $additionalGroups), $displayGroup, $uid]);
     }
 
     /**

--- a/includes/ServiceModules/MybbExtraGroups/MybbUserGroupRepository.php
+++ b/includes/ServiceModules/MybbExtraGroups/MybbUserGroupRepository.php
@@ -43,7 +43,7 @@ class MybbUserGroupRepository
                 "INSERT INTO `ss_mybb_user_group` (`uid`, `gid`, `expire`, `was_before`) VALUES " .
                     $queryParticle->text(", ")
             )
-            ->execute($queryParticle->params());
+            ->bindAndExecute($queryParticle->params());
     }
 
     /**
@@ -51,7 +51,7 @@ class MybbUserGroupRepository
      */
     public function delete($id): void
     {
-        $this->db->statement("DELETE FROM `ss_mybb_user_group` WHERE `uid` = ?")->execute([$id]);
+        $this->db->statement("DELETE FROM `ss_mybb_user_group` WHERE `uid` = ?")->bindAndExecute([$id]);
     }
 
     /**
@@ -64,7 +64,7 @@ class MybbUserGroupRepository
             "SELECT `gid`, UNIX_TIMESTAMP(`expire`) - UNIX_TIMESTAMP() AS `expire`, `was_before` FROM `ss_mybb_user_group` " .
                 "WHERE `uid` = ?"
         );
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
         return $statement->fetchAll();
     }
 }

--- a/includes/ServiceModules/MybbExtraGroups/MybbUserGroupRepository.php
+++ b/includes/ServiceModules/MybbExtraGroups/MybbUserGroupRepository.php
@@ -51,7 +51,9 @@ class MybbUserGroupRepository
      */
     public function delete($id): void
     {
-        $this->db->statement("DELETE FROM `ss_mybb_user_group` WHERE `uid` = ?")->bindAndExecute([$id]);
+        $this->db
+            ->statement("DELETE FROM `ss_mybb_user_group` WHERE `uid` = ?")
+            ->bindAndExecute([$id]);
     }
 
     /**

--- a/includes/ServiceModules/MybbExtraGroups/MybbUserServiceRepository.php
+++ b/includes/ServiceModules/MybbExtraGroups/MybbUserServiceRepository.php
@@ -50,7 +50,7 @@ class MybbUserServiceRepository
             ->statement(
                 "INSERT INTO `{$table}` (`us_id`, `service_id`, `mybb_uid`) VALUES (?, ?, ?)"
             )
-            ->execute([$userServiceId, $serviceId, $mybbUid]);
+            ->bindAndExecute([$userServiceId, $serviceId, $mybbUid]);
 
         return $this->get($userServiceId);
     }
@@ -68,7 +68,7 @@ class MybbUserServiceRepository
                     "INNER JOIN `$table` AS m ON m.us_id = us.id " .
                     "WHERE `id` = ?"
             );
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -84,7 +84,7 @@ class MybbUserServiceRepository
         $statement = $this->db->statement(
             "SELECT `us_id` FROM `{$table}` WHERE `service_id` = ? AND `mybb_uid` = ?"
         );
-        $statement->execute([$serviceId, $mybbUid]);
+        $statement->bindAndExecute([$serviceId, $mybbUid]);
 
         if ($data = $statement->fetch()) {
             return $this->mapToModel($data);

--- a/includes/Support/PDOStatement.php
+++ b/includes/Support/PDOStatement.php
@@ -7,7 +7,7 @@ use PDOStatement as BasePDOStatement;
 
 class PDOStatement extends BasePDOStatement
 {
-    public function execute($params = null)
+    public function bindAndExecute(array $params)
     {
         if ($params) {
             $i = 1;

--- a/includes/System/CronExecutor.php
+++ b/includes/System/CronExecutor.php
@@ -43,7 +43,7 @@ class CronExecutor
                 ->statement(
                     "DELETE FROM `ss_logs` WHERE `timestamp` < DATE_SUB(NOW(), INTERVAL ? DAY)"
                 )
-                ->execute([$this->settings->getDeleteLogs()]);
+                ->bindAndExecute([$this->settings->getDeleteLogs()]);
         }
 
         // Remove files older than 30 days from data/transactions

--- a/includes/Theme/TemplateRepository.php
+++ b/includes/Theme/TemplateRepository.php
@@ -44,7 +44,11 @@ class TemplateRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_templates` WHERE `name` = ? AND `theme` = ? AND `lang` = ?"
         );
-        $statement->bindAndExecute([$name, $theme ?: self::DEFAULT_THEME, $lang ?: self::DEFAULT_THEME]);
+        $statement->bindAndExecute([
+            $name,
+            $theme ?: self::DEFAULT_THEME,
+            $lang ?: self::DEFAULT_THEME,
+        ]);
         $data = $statement->fetch();
 
         return $data ? $this->mapToModel($data) : null;

--- a/includes/Theme/TemplateRepository.php
+++ b/includes/Theme/TemplateRepository.php
@@ -23,7 +23,7 @@ class TemplateRepository
     {
         if ($id) {
             $statement = $this->db->statement("SELECT * FROM `ss_templates` WHERE `id` = ?");
-            $statement->execute([$id]);
+            $statement->bindAndExecute([$id]);
 
             if ($data = $statement->fetch()) {
                 return $this->mapToModel($data);
@@ -44,7 +44,7 @@ class TemplateRepository
         $statement = $this->db->statement(
             "SELECT * FROM `ss_templates` WHERE `name` = ? AND `theme` = ? AND `lang` = ?"
         );
-        $statement->execute([$name, $theme ?: self::DEFAULT_THEME, $lang ?: self::DEFAULT_THEME]);
+        $statement->bindAndExecute([$name, $theme ?: self::DEFAULT_THEME, $lang ?: self::DEFAULT_THEME]);
         $data = $statement->fetch();
 
         return $data ? $this->mapToModel($data) : null;
@@ -66,7 +66,7 @@ class TemplateRepository
                 SET `name` = ?, `theme` = ?, `lang` = ?, `content` = ?, `created_at` = NOW(), `updated_at` = NOW()
 EOF
             )
-            ->execute([
+            ->bindAndExecute([
                 $name,
                 $theme ?: self::DEFAULT_THEME,
                 $lang ?: self::DEFAULT_THEME,
@@ -90,7 +90,7 @@ EOF
                 WHERE `id` = ?
 EOF
             )
-            ->execute([$content, $id]);
+            ->bindAndExecute([$content, $id]);
     }
 
     /**
@@ -100,7 +100,7 @@ EOF
     public function delete($id): bool
     {
         $statement = $this->db->statement("DELETE FROM `ss_templates` WHERE `id` = ?");
-        $statement->execute([$id]);
+        $statement->bindAndExecute([$id]);
         return !!$statement->rowCount();
     }
 
@@ -118,7 +118,7 @@ EOF
             ORDER BY `theme` ASC
 EOF
         );
-        $statement->execute([self::DEFAULT_THEME]);
+        $statement->bindAndExecute([self::DEFAULT_THEME]);
 
         return collect($statement)
             ->map(fn(array $row) => $row["theme"])
@@ -139,7 +139,7 @@ EOF
             ORDER BY `name` ASC
 EOF
         );
-        $statement->execute([$theme ?: self::DEFAULT_THEME, $lang ?: self::DEFAULT_THEME]);
+        $statement->bindAndExecute([$theme ?: self::DEFAULT_THEME, $lang ?: self::DEFAULT_THEME]);
 
         return collect($statement)
             ->map(fn(array $row) => $this->mapToModel($row))

--- a/includes/View/Pages/Admin/PageAdminBoughtServices.php
+++ b/includes/View/Pages/Admin/PageAdminBoughtServices.php
@@ -98,7 +98,7 @@ class PageAdminBoughtServices extends PageAdmin
                 "ORDER BY t.timestamp DESC " .
                 "LIMIT ?, ?"
         );
-        $statement->execute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminBoughtServices.php
+++ b/includes/View/Pages/Admin/PageAdminBoughtServices.php
@@ -98,7 +98,9 @@ class PageAdminBoughtServices extends PageAdmin
                 "ORDER BY t.timestamp DESC " .
                 "LIMIT ?, ?"
         );
-        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(
+            array_merge($queryParticle->params(), $pagination->getSqlLimit())
+        );
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminGroups.php
+++ b/includes/View/Pages/Admin/PageAdminGroups.php
@@ -58,7 +58,7 @@ class PageAdminGroups extends PageAdmin implements IPageAdminActionBox
         $statement = $this->db->statement(
             "SELECT SQL_CALC_FOUND_ROWS * FROM `ss_groups` LIMIT ?, ?"
         );
-        $statement->execute($pagination->getSqlLimit());
+        $statement->bindAndExecute($pagination->getSqlLimit());
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminLogs.php
+++ b/includes/View/Pages/Admin/PageAdminLogs.php
@@ -62,7 +62,9 @@ class PageAdminLogs extends PageAdmin
         $statement = $this->db->statement(
             "SELECT SQL_CALC_FOUND_ROWS * FROM `ss_logs` {$where} ORDER BY `id` DESC LIMIT ?, ?"
         );
-        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(
+            array_merge($queryParticle->params(), $pagination->getSqlLimit())
+        );
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminLogs.php
+++ b/includes/View/Pages/Admin/PageAdminLogs.php
@@ -62,7 +62,7 @@ class PageAdminLogs extends PageAdmin
         $statement = $this->db->statement(
             "SELECT SQL_CALC_FOUND_ROWS * FROM `ss_logs` {$where} ORDER BY `id` DESC LIMIT ?, ?"
         );
-        $statement->execute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminPaymentPlatforms.php
+++ b/includes/View/Pages/Admin/PageAdminPaymentPlatforms.php
@@ -73,7 +73,7 @@ class PageAdminPaymentPlatforms extends PageAdmin implements IPageAdminActionBox
         $statement = $this->db->statement(
             "SELECT SQL_CALC_FOUND_ROWS * FROM `ss_payment_platforms` LIMIT ?, ?"
         );
-        $statement->execute($pagination->getSqlLimit());
+        $statement->bindAndExecute($pagination->getSqlLimit());
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminPayments.php
+++ b/includes/View/Pages/Admin/PageAdminPayments.php
@@ -115,7 +115,7 @@ class PageAdminPayments extends PageAdmin
                 "ORDER BY t.timestamp DESC " .
                 "LIMIT ?, ?"
         );
-        $statement->execute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminPayments.php
+++ b/includes/View/Pages/Admin/PageAdminPayments.php
@@ -115,7 +115,9 @@ class PageAdminPayments extends PageAdmin
                 "ORDER BY t.timestamp DESC " .
                 "LIMIT ?, ?"
         );
-        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(
+            array_merge($queryParticle->params(), $pagination->getSqlLimit())
+        );
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminPlayersFlags.php
+++ b/includes/View/Pages/Admin/PageAdminPlayersFlags.php
@@ -62,7 +62,7 @@ class PageAdminPlayersFlags extends PageAdmin
                 "ORDER BY `id` DESC " .
                 "LIMIT ?, ?"
         );
-        $statement->execute($pagination->getSqlLimit());
+        $statement->bindAndExecute($pagination->getSqlLimit());
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminPricing.php
+++ b/includes/View/Pages/Admin/PageAdminPricing.php
@@ -87,7 +87,7 @@ ORDER BY `service_id`, `server_id`, `quantity`
 LIMIT ?, ?
 EOF
         );
-        $statement->execute($pagination->getSqlLimit());
+        $statement->bindAndExecute($pagination->getSqlLimit());
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminPromoCodes.php
+++ b/includes/View/Pages/Admin/PageAdminPromoCodes.php
@@ -78,7 +78,7 @@ class PageAdminPromoCodes extends PageAdmin implements IPageAdminActionBox
         $statement = $this->db->statement(
             "SELECT SQL_CALC_FOUND_ROWS *" . "FROM `ss_promo_codes` AS sc " . "LIMIT ?, ?"
         );
-        $statement->execute($pagination->getSqlLimit());
+        $statement->bindAndExecute($pagination->getSqlLimit());
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminSmsCodes.php
+++ b/includes/View/Pages/Admin/PageAdminSmsCodes.php
@@ -72,7 +72,7 @@ class PageAdminSmsCodes extends PageAdmin implements IPageAdminActionBox
                 "WHERE `free` = '1' " .
                 "LIMIT ?, ?"
         );
-        $statement->execute($pagination->getSqlLimit());
+        $statement->bindAndExecute($pagination->getSqlLimit());
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminUsers.php
+++ b/includes/View/Pages/Admin/PageAdminUsers.php
@@ -109,7 +109,7 @@ class PageAdminUsers extends PageAdmin implements IPageAdminActionBox
         $statement = $this->db->statement(
             "SELECT SQL_CALC_FOUND_ROWS * FROM `ss_users` {$where} LIMIT ?, ?"
         );
-        $statement->execute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Admin/PageAdminUsers.php
+++ b/includes/View/Pages/Admin/PageAdminUsers.php
@@ -109,7 +109,9 @@ class PageAdminUsers extends PageAdmin implements IPageAdminActionBox
         $statement = $this->db->statement(
             "SELECT SQL_CALC_FOUND_ROWS * FROM `ss_users` {$where} LIMIT ?, ?"
         );
-        $statement->bindAndExecute(array_merge($queryParticle->params(), $pagination->getSqlLimit()));
+        $statement->bindAndExecute(
+            array_merge($queryParticle->params(), $pagination->getSqlLimit())
+        );
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $bodyRows = collect($statement)

--- a/includes/View/Pages/Shop/PagePaymentLog.php
+++ b/includes/View/Pages/Shop/PagePaymentLog.php
@@ -69,7 +69,7 @@ class PagePaymentLog extends Page implements IBeLoggedMust
                 "ORDER BY t.timestamp DESC " .
                 "LIMIT ?, ?"
         );
-        $statement->execute(array_merge([$user->getId()], $pagination->getSqlLimit(10)));
+        $statement->bindAndExecute(array_merge([$user->getId()], $pagination->getSqlLimit(10)));
         $rowsCount = $this->db->query("SELECT FOUND_ROWS()")->fetchColumn();
 
         $paymentLogs = "";

--- a/includes/View/Pages/Shop/PageUserOwnServices.php
+++ b/includes/View/Pages/Shop/PageUserOwnServices.php
@@ -75,7 +75,7 @@ class PageUserOwnServices extends Page implements IBeLoggedMust
                     "INNER JOIN `ss_services` AS s ON us.service_id = s.id " .
                     "WHERE us.user_id = ? AND s.module IN ({$keys}) "
             );
-            $statement->execute(array_merge([$user->getId()], $moduleIds->all()));
+            $statement->bindAndExecute(array_merge([$user->getId()], $moduleIds->all()));
             $rowsCount = $statement->fetchColumn();
 
             $statement = $this->db->statement(
@@ -87,7 +87,7 @@ ORDER BY us.id DESC
 LIMIT ?, ?
 EOF
             );
-            $statement->execute(
+            $statement->bindAndExecute(
                 array_merge([$user->getId()], $moduleIds->all(), $pagination->getSqlLimit(4))
             );
 

--- a/migrations/2018_12_25_205300_change_cssetti_numbers.php
+++ b/migrations/2018_12_25_205300_change_cssetti_numbers.php
@@ -43,6 +43,6 @@ class ChangeCssettiNumbers extends Migration
 
         $this->db
             ->statement("UPDATE `ss_transaction_services` SET `data` = ? WHERE `id` = 'cssetti';")
-            ->execute([json_encode($data)]);
+            ->bindAndExecute([json_encode($data)]);
     }
 }

--- a/migrations/2019_12_31_002400_migrate_transaction_services.php
+++ b/migrations/2019_12_31_002400_migrate_transaction_services.php
@@ -53,7 +53,7 @@ class MigrateTransactionServices extends Migration
                         "INSERT INTO `ss_payment_platforms` " .
                             "SET `name` = ?, `module` = ?, `data` = ?"
                     )
-                    ->execute([$row["name"], $row["id"], json_encode($data)]);
+                    ->bindAndExecute([$row["name"], $row["id"], json_encode($data)]);
 
                 $paymentPlatforms[$row["id"]] = $this->db->lastId();
             }
@@ -63,20 +63,20 @@ class MigrateTransactionServices extends Migration
         $newSmsPlatformId = array_get($paymentPlatforms, $smsService, "");
         $this->db
             ->statement("UPDATE `ss_settings` SET `value` = ? WHERE `key` = 'sms_service'")
-            ->execute([$newSmsPlatformId]);
+            ->bindAndExecute([$newSmsPlatformId]);
 
         /** @var PaymentPlatform|null $newTransferPlatform */
         $newTransferPlatformId = array_get($paymentPlatforms, $transferService, "");
         $this->db
             ->statement("UPDATE `ss_settings` SET `value` = ? WHERE `key` = 'transfer_service'")
-            ->execute([$newTransferPlatformId]);
+            ->bindAndExecute([$newTransferPlatformId]);
 
         $statement = $this->db->query("SELECT * FROM ss_servers");
         foreach ($statement as $row) {
             $smsPlatformId = array_get($paymentPlatforms, $row["sms_service"]);
             $this->db
                 ->statement("UPDATE `ss_servers` SET `sms_service` = ? WHERE `id` = ?")
-                ->execute([$smsPlatformId, $row["id"]]);
+                ->bindAndExecute([$smsPlatformId, $row["id"]]);
         }
 
         $this->db->query(

--- a/migrations/2020_01_11_204500_price_table.php
+++ b/migrations/2020_01_11_204500_price_table.php
@@ -56,7 +56,7 @@ INSERT INTO `ss_prices` (`service`, `server`, `sms_price`, `transfer_price`, `qu
 VALUES (?, ?, ?, ?, ?)
 EOF
                     )
-                    ->execute([
+                    ->bindAndExecute([
                         $row["service"],
                         $row["server"] === -1 ? null : $row["server"],
                         $this->tariffToSmsPrice($row["tariff"]),
@@ -89,7 +89,7 @@ EOF
             try {
                 $this->db
                     ->statement("UPDATE ss_service_codes SET `price` = ? WHERE `id` = ?")
-                    ->execute([array_get($tariffPrice, $row["tariff"]), $row["id"]]);
+                    ->bindAndExecute([array_get($tariffPrice, $row["tariff"]), $row["id"]]);
             } catch (PDOException $e) {
                 $this->fileLogger->install("Migrate service_code error. {$e->getMessage()}");
             }

--- a/migrations/2020_04_22_174000_license_token.php
+++ b/migrations/2020_04_22_174000_license_token.php
@@ -11,7 +11,7 @@ class LicenseToken extends Migration
             ->fetchColumn();
         $this->db
             ->statement("INSERT INTO `ss_settings` SET `key` = 'license_token', `value` = ?")
-            ->execute([$licenseToken]);
+            ->bindAndExecute([$licenseToken]);
         $this->db->query(
             "DELETE FROM `ss_settings` WHERE `key` IN ('license_login', 'license_password')"
         );

--- a/migrations/2020_04_24_105400_replace_prices_price_with_quantity.php
+++ b/migrations/2020_04_24_105400_replace_prices_price_with_quantity.php
@@ -15,7 +15,7 @@ class ReplacePricesPriceWithQuantity extends Migration
         foreach ($statement as $row) {
             $this->db
                 ->statement("UPDATE `ss_service_codes` SET `quantity` = ? WHERE `id` = ?")
-                ->execute([$row["quantity"], $row["id"]]);
+                ->bindAndExecute([$row["quantity"], $row["id"]]);
         }
 
         $this->executeQueries([

--- a/migrations/2020_05_10_115500_replace_service_code_with_promo_code.php
+++ b/migrations/2020_05_10_115500_replace_service_code_with_promo_code.php
@@ -29,7 +29,7 @@ class ReplaceServiceCodeWithPromoCode extends Migration
                 ->statement(
                     "UPDATE `ss_promo_codes` SET `quantity_type` = 'percentage', `server_id` = ?, `user_id` = ? WHERE `id` = ?"
                 )
-                ->execute([
+                ->bindAndExecute([
                     $serviceCode["server"] ?: null,
                     $serviceCode["user_id"] ?: null,
                     $serviceCode["id"],

--- a/migrations/2020_06_19_114000_refactor_groups.php
+++ b/migrations/2020_06_19_114000_refactor_groups.php
@@ -44,7 +44,7 @@ class RefactorGroups extends Migration
                 ->keys()
                 ->join(",");
 
-            $statement->execute([$permissions, $row["id"]]);
+            $statement->bindAndExecute([$permissions, $row["id"]]);
         }
 
         foreach ($privileges as $permission) {

--- a/migrations/2022_03_19_005300_add_pricing_permissions.php
+++ b/migrations/2022_03_19_005300_add_pricing_permissions.php
@@ -15,7 +15,7 @@ class AddPricingPermissions extends Migration
 
                 $this->db
                     ->statement("UPDATE `ss_groups` SET `permissions` = ? WHERE `id` = ?")
-                    ->execute([$newPermissions, $row["id"]]);
+                    ->bindAndExecute([$newPermissions, $row["id"]]);
             }
         }
     }

--- a/tests/Psr4/TestCases/TestCase.php
+++ b/tests/Psr4/TestCases/TestCase.php
@@ -68,7 +68,7 @@ class TestCase extends UnitTestCase
         $params = implode(" AND ", $params);
 
         $statement = $db->statement("SELECT 1 FROM `{$table}` WHERE {$params}");
-        $statement->execute($values);
+        $statement->bindAndExecute($values);
 
         return $statement->rowCount() > 0;
     }


### PR DESCRIPTION
Interface of `PDOStatement.execute()` accepts `string[]` as input params (because it treats each of them as if they were bound with `PDO::PARAM_STR`).

By mapping types to `int`/`bool` and other types, you're essentially changing the API to accept `(int|string|bool||null)[]`, which is a different interface. They may be represented by the same method signatures, but they're used differently.

So in my opinion, despite the name "`execute()`" these methods are actually different methods, and pretending they're the same will lead to problems. 

PS: On the other hand, some might argue that `(int|string|bool||null)[]` is a super set of `string[]`, just like generics, so it maybe it is the same method after all.
PS2: On the third hand, it's not the same method because you can't use `execute()` to map anything to `PDO::PARAM_INT`.