### PR TITLE
Don't list steam ids

### DIFF
--- a/includes/Http/Controllers/Api/Server/ServerConfigController.php
+++ b/includes/Http/Controllers/Api/Server/ServerConfigController.php
@@ -107,10 +107,6 @@ class ServerConfigController
             fn(SmsNumber $smsNumber) => $smsNumber->getNumber()
         );
 
-        $steamIds = collect($userRepository->allWithSteamId())
-            ->map(fn(User $user) => $user->getSteamId())
-            ->join(";");
-
         $serverRepository->touch($server->getId(), $platform, $version);
 
         $data = merge_recursive(
@@ -119,7 +115,6 @@ class ServerConfigController
                 "license_token" => $settings->getLicenseToken(),
                 "sms_platform_id" => $smsPlatformId,
                 "sms_text" => $smsModule->getSmsCode(),
-                "steam_ids" => "$steamIds;",
                 "currency" => $settings->getCurrency(),
                 "contact" => $settings->getContactEmail(),
                 "vat" => $settings->getVat(),

--- a/includes/Repositories/UserRepository.php
+++ b/includes/Repositories/UserRepository.php
@@ -101,17 +101,6 @@ EOF
     }
 
     /**
-     * @return User[]
-     */
-    public function allWithSteamId(): array
-    {
-        $statement = $this->db->query("SELECT * FROM `ss_users` WHERE `steam_id` IS NOT NULL");
-        return collect($statement)
-            ->map(fn(array $row) => $this->mapToModel($row))
-            ->all();
-    }
-
-    /**
      * @param int|null $id
      * @return User|null
      */

--- a/tests/Feature/Http/Api/Server/PurchaseResourceOtherSmsTest.php
+++ b/tests/Feature/Http/Api/Server/PurchaseResourceOtherSmsTest.php
@@ -74,19 +74,23 @@ class PurchaseResourceOtherSmsTest extends HttpTestCase
                 "token" => $server->getToken(),
             ],
             [
+                "Accept" => "application/json",
                 "User-Agent" => Platform::AMXMODX,
             ]
         );
 
         // then
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertMatchesRegularExpression(
-            "#<return_value>purchased</return_value><text>Usługa została prawidłowo zakupiona\.</text><positive>1</positive><bsid>\d+</bsid>#",
-            $response->getContent()
+        $json = $this->decodeJsonResponse($response);
+        $this->assertArraySubset(
+            [
+                "status" => "purchased",
+                "text" => "Usługa została prawidłowo zakupiona.",
+            ],
+            $json
         );
 
-        preg_match("#<bsid>(\d+)</bsid>#", $response->getContent(), $matches);
-        $boughtServiceId = $matches[1];
+        $boughtServiceId = $json["bsid"];
         $boughtService = $boughtServiceRepository->get($boughtServiceId);
         $this->assertNotNull($boughtService);
         $this->assertSameEnum(PaymentMethod::SMS(), $boughtService->getMethod());

--- a/tests/Feature/Http/Api/Server/ServerConfigControllerTest.php
+++ b/tests/Feature/Http/Api/Server/ServerConfigControllerTest.php
@@ -70,7 +70,6 @@ class ServerConfigControllerTest extends HttpTestCase
             "license_token:abc123",
             "sms_platform_id:{$this->paymentPlatform->getId()}",
             "sms_text:abc123",
-            "steam_ids:;",
             "currency:PLN",
             "contact:",
             "vat:1.23",
@@ -130,43 +129,6 @@ class ServerConfigControllerTest extends HttpTestCase
         $this->assertSame($this->paymentPlatform->getId(), $json["sms_platform_id"]);
         $this->assertSame($this->settings->getVat(), $json["vat"]);
         $this->assertSame("abc123", $json["license_token"]);
-    }
-
-    /** @test */
-    public function lists_users_steam_ids()
-    {
-        // given
-        $this->factory->user([
-            "steam_id" => "STEAM_1",
-        ]);
-        $this->factory->user([
-            "steam_id" => "STEAM_12",
-        ]);
-        $this->factory->user();
-        $this->factory->user([
-            "steam_id" => "STEAM_2",
-        ]);
-
-        // when
-        $response = $this->get(
-            "api/server/config",
-            [
-                "token" => $this->server->getToken(),
-                "ip" => $this->server->getIp(),
-                "port" => $this->server->getPort(),
-                "version" => "3.9.0",
-            ],
-            [
-                "User-Agent" => Platform::SOURCEMOD,
-            ]
-        );
-
-        // then
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertStringContainsString(
-            "steam_ids:STEAM_1;STEAM_12;STEAM_2;",
-            $response->getContent()
-        );
     }
 
     /** @test */

--- a/translations/english/user/general.php
+++ b/translations/english/user/general.php
@@ -58,7 +58,8 @@ return [
     "logout_success" => "Logging out successful.",
     "my_services" => "My services",
     "nick_occupied" => "Given nickname is already taken.",
-    "no_login_no_wallet" => "In order to pay using wallet you need to create a shop account and provide your SteamID in the profile section.",
+    "no_login_no_wallet" =>
+        "In order to pay using wallet you need to create a shop account and provide your SteamID in the profile section.",
     "no_login_password" =>
         'Unfortunately, without providing nickname and login, you can\'t log in.',
     "no_reset_key" => "No reset key was given.",

--- a/translations/polish/user/general.php
+++ b/translations/polish/user/general.php
@@ -58,7 +58,8 @@ return [
     "logout_success" => "Wylogowywanie przebiegło bez większych trudności.",
     "my_services" => "Moje usługi",
     "nick_occupied" => "Podana nazwa użytkownika jest już zajęta.",
-    "no_login_no_wallet" => "Płatność portfelem jest możliwa po utworzeniu konta w sklepie oraz podaniu swojego SteamID w profilu.",
+    "no_login_no_wallet" =>
+        "Płatność portfelem jest możliwa po utworzeniu konta w sklepie oraz podaniu swojego SteamID w profilu.",
     "no_login_password" =>
         "No niestety, ale bez podania nazwy użytkownika oraz loginu, nie zalogujesz się.",
     "no_reset_key" => "Nie podano kodu resetowania hasła.",


### PR DESCRIPTION
Server doesn't need to check steam id upfront. Let it make a request, so that backend can handle checking steam id.