### PR TITLE
fix: add --no-run-if-empty to xargs to prevent rm errors when no files match

### DIFF
--- a/remove_unnecessary_files.sh
+++ b/remove_unnecessary_files.sh
@@ -2,16 +2,16 @@
 
 find vendor -type d | \
 grep -iE "/\.?(demo|doc|docs|example|examples|test|tests|github|circleci|travis)$" | \
-xargs rm -r
+xargs --no-run-if-empty rm -r
 
 find vendor -type f | \
 grep -iE "/\.?(readme|changelog|faq|contributing|history|upgrading|upgrade|package|composer|travis|psalm|phpmd|scrutinizer|coveralls|gush|phpstorm)\.[^/]+$" | \
-xargs rm -r
+xargs --no-run-if-empty rm -r
 
 find vendor -type f | \
 grep -iE "/\.?(php_cs|phpstan|gitignore|gitattributes|editorconfig)[^/]+$" | \
-xargs rm -r
+xargs --no-run-if-empty rm -r
 
 find vendor -type f | \
 grep -iE "/(phpunit\.xml|phpunit\.xml\.dist)$" | \
-xargs rm -r
+xargs --no-run-if-empty rm -r


### PR DESCRIPTION
When `find` returns no results, `xargs` calls `rm -r` with no arguments, causing `rm: missing operand` errors in CI.

Adding `--no-run-if-empty` prevents running `rm` when there are no matches.
