### PR TITLE
fix: correct GITHUB_OUTPUT syntax and replace deprecated upload-release-asset action

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -96,23 +96,14 @@ jobs:
           favicon.png \
           index.php \
           README.md
-          echo "{ARTIFACT_PATH}={./$BUILD_NAME}" >> $GITHUB_OUTPUT
-          echo "{ARTIFACT_NAME}={$BUILD_NAME}" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_PATH=./$BUILD_NAME" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_NAME=$BUILD_NAME" >> $GITHUB_OUTPUT
         env:
           BUILD_NAME: build-${{ matrix.php_version }}.zip
 
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.3.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.2
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.build_artifact.outputs.ARTIFACT_PATH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ${{ steps.build_artifact.outputs.ARTIFACT_PATH }}
-          asset_name: ${{ steps.build_artifact.outputs.ARTIFACT_NAME }}
-          asset_content_type: application/zip


### PR DESCRIPTION
Fixed two issues in the release workflow:

1. **GITHUB_OUTPUT syntax**: Was using `{ARTIFACT_PATH}={./$BUILD_NAME}` which is incorrect format. Fixed to `ARTIFACT_PATH=./$BUILD_NAME`. This caused `asset_path` to be empty, resulting in "Input required and not supplied: asset_path".

2. **Deprecated action**: Replaced `actions/upload-release-asset@v1.0.2` (archived, uses Node 20) with `softprops/action-gh-release@v2`. Also removed the now-unused `bruceadams/get-release` step.
