### PR TITLE
Fix two Sentry TypeError issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,31 @@ License can be purchased here: https://sklep.sklep-sms.pl
 ## Installation
 How to install the Sklep SMS step by step: https://sklep-sms.pl/config
 
+## Development
+
+### Setup
+
+```bash
+# Start services
+docker-compose up -d
+
+# Install dependencies (uses composer-v8.0.json for PHP 8.0 compatibility)
+docker-compose exec -T app bash -c "COMPOSER=composer-v8.0.json composer install --no-interaction --no-plugins"
+
+# Set up test database
+docker-compose exec -T app php artisan test:setup
+```
+
+### Running tests
+
+```bash
+# Run all tests
+docker-compose exec -T app php vendor/bin/phpunit
+
+# Run a specific test
+docker-compose exec -T app php vendor/bin/phpunit --filter TestName
+```
+
 ## Contact
 * [#wsparcie](https://discord.gg/fz47ngSzGy) channel
 * [Issues](https://github.com/gammerce/sklep-sms/issues) tab

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ docker-compose up -d
 # Install dependencies (uses composer-v8.0.json for PHP 8.0 compatibility)
 docker-compose exec -T app bash -c "COMPOSER=composer-v8.0.json composer install --no-interaction --no-plugins"
 
+# Install production dependencies only (no dev)
+docker-compose exec -T app bash -c "COMPOSER=composer-v8.0.json composer install --no-dev --no-interaction --no-plugins"
+
 # Set up test database
 docker-compose exec -T app php artisan test:setup
 ```

--- a/includes/View/Pages/Shop/PagePayment.php
+++ b/includes/View/Pages/Shop/PagePayment.php
@@ -37,6 +37,10 @@ class PagePayment extends Page
     public function getContent(Request $request)
     {
         $transactionId = $request->query->get("tid");
+        if (!$transactionId) {
+            throw new EntityNotFoundException();
+        }
+
         $purchase = $this->purchaseDataService->restorePurchase($transactionId);
 
         if (!$purchase) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -311,7 +311,9 @@ function captureRequest(): Request
 {
     $queryAttributes = [];
     foreach ($_GET as $key => $value) {
-        $queryAttributes[$key] = urldecode($value);
+        $queryAttributes[$key] = is_array($value)
+            ? array_map("urldecode", $value)
+            : urldecode($value);
     }
 
     $request = Request::createFromGlobals();

--- a/tests/Feature/Http/ArrayQueryParamTest.php
+++ b/tests/Feature/Http/ArrayQueryParamTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace Tests\Feature\Http;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Psr4\TestCases\HttpTestCase;
+
+class ArrayQueryParamTest extends HttpTestCase
+{
+    /** @test */
+    public function it_handles_array_query_parameters()
+    {
+        $response = $this->get("/", [
+            "platforms" => ["sourcemod"],
+            "amount" =>
+                "📊 Transfer 236,538 $. GET ->> graph.org/BALANCE-3682444-USD-04-21-2?hs=65b37b7e4f3e8d19facd05e1ea79ca1f& 📊",
+            "subdomain" => "x68sld",
+            "email" => "v4yc92xhbbuyca@web-library.net",
+            "service_id" => "ss_license",
+        ]);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Http/View/Shop/PaymentTest.php
+++ b/tests/Feature/Http/View/Shop/PaymentTest.php
@@ -99,4 +99,14 @@ class PaymentTest extends HttpTestCase
         $this->assertStringContainsString("Płatność", $response->getContent());
         $this->assertStringContainsString("Szczegóły zamówienia", $response->getContent());
     }
+
+    /** @test */
+    public function returns_404_when_tid_is_missing()
+    {
+        // when
+        $response = $this->get("/page/payment");
+
+        // then
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
 }

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class FunctionsTest extends TestCase
+{
+    private array $originalGet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalGet = $_GET;
+    }
+
+    protected function tearDown(): void
+    {
+        $_GET = $this->originalGet;
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function decodes_string_query_parameters()
+    {
+        $_GET = [
+            "service_id" => "ss_license",
+            "email" => "v4yc92xhbbuyca%40web-library.net",
+        ];
+
+        $request = \captureRequest();
+
+        $this->assertSame("ss_license", $request->query->get("service_id"));
+        $this->assertSame("v4yc92xhbbuyca@web-library.net", $request->query->get("email"));
+    }
+
+    /** @test */
+    public function decodes_array_query_parameters()
+    {
+        $_GET = [
+            "platforms" => ["sourcemod"],
+            "amount" => "%F0%9F%93%8A+Transfer",
+        ];
+
+        $request = \captureRequest();
+
+        $this->assertSame(["sourcemod"], $request->query->all()["platforms"]);
+        $this->assertSame("📊 Transfer", $request->query->get("amount"));
+    }
+}

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -1,11 +1,9 @@
 <?php
 namespace Tests\Unit;
 
-use App\Kernels\KernelContract;
-use Symfony\Component\HttpFoundation\Response;
-use Tests\Psr4\TestCases\UnitTestCase;
+use PHPUnit\Framework\TestCase;
 
-class FunctionsTest extends UnitTestCase
+class FunctionsTest extends TestCase
 {
     private array $originalGet;
 
@@ -22,29 +20,16 @@ class FunctionsTest extends UnitTestCase
     }
 
     /** @test */
-    public function request_with_array_query_does_not_crash()
+    public function decodes_array_query_parameters()
     {
         $_GET = [
             "platforms" => ["sourcemod"],
-            "amount" =>
-                "📊 Transfer 236,538 $. GET ->> graph.org/BALANCE-3682444-USD-04-21-2?hs=65b37b7e4f3e8d19facd05e1ea79ca1f& 📊",
-            "subdomain" => "x68sld",
-            "email" => "v4yc92xhbbuyca@web-library.net",
-            "service_id" => "ss_license",
+            "amount" => "%F0%9F%93%8A+Transfer",
         ];
 
         $request = \captureRequest();
 
-        /** @var KernelContract $kernel */
-        $kernel = $this->app->make(KernelContract::class);
-        $response = $kernel->handle($request);
-        $kernel->terminate($request, $response);
-
-        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(["sourcemod"], $request->query->all()["platforms"]);
-        $this->assertStringContainsString(
-            "📊 Transfer 236,538 $. GET ->> graph.org/BALANCE-3682444-USD-04-21-2?hs=65b37b7e4f3e8d19facd05e1ea79ca1f& 📊",
-            $request->query->get("amount")
-        );
+        $this->assertSame("📊 Transfer", $request->query->get("amount"));
     }
 }

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -1,10 +1,11 @@
 <?php
 namespace Tests\Unit;
 
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
+use App\Kernels\KernelContract;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Psr4\TestCases\UnitTestCase;
 
-class FunctionsTest extends TestCase
+class FunctionsTest extends UnitTestCase
 {
     private array $originalGet;
 
@@ -21,30 +22,29 @@ class FunctionsTest extends TestCase
     }
 
     /** @test */
-    public function decodes_string_query_parameters()
-    {
-        $_GET = [
-            "service_id" => "ss_license",
-            "email" => "v4yc92xhbbuyca%40web-library.net",
-        ];
-
-        $request = \captureRequest();
-
-        $this->assertSame("ss_license", $request->query->get("service_id"));
-        $this->assertSame("v4yc92xhbbuyca@web-library.net", $request->query->get("email"));
-    }
-
-    /** @test */
-    public function decodes_array_query_parameters()
+    public function request_with_array_query_does_not_crash()
     {
         $_GET = [
             "platforms" => ["sourcemod"],
-            "amount" => "%F0%9F%93%8A+Transfer",
+            "amount" =>
+                "📊 Transfer 236,538 $. GET ->> graph.org/BALANCE-3682444-USD-04-21-2?hs=65b37b7e4f3e8d19facd05e1ea79ca1f& 📊",
+            "subdomain" => "x68sld",
+            "email" => "v4yc92xhbbuyca@web-library.net",
+            "service_id" => "ss_license",
         ];
 
         $request = \captureRequest();
 
+        /** @var KernelContract $kernel */
+        $kernel = $this->app->make(KernelContract::class);
+        $response = $kernel->handle($request);
+        $kernel->terminate($request, $response);
+
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(["sourcemod"], $request->query->all()["platforms"]);
-        $this->assertSame("📊 Transfer", $request->query->get("amount"));
+        $this->assertStringContainsString(
+            "📊 Transfer 236,538 $. GET ->> graph.org/BALANCE-3682444-USD-04-21-2?hs=65b37b7e4f3e8d19facd05e1ea79ca1f& 📊",
+            $request->query->get("amount")
+        );
     }
 }


### PR DESCRIPTION
Fixes two TypeError issues reported in Sentry:

### 1. PagePayment: missing tid query param
```
TypeError: PurchaseDataService::restorePurchase(): Argument #1 () 
must be of type string, null given
```
Accessing `/page/payment` without `?tid=` caused a TypeError. Added a null check 
that throws EntityNotFoundException (404), consistent with the existing behavior 
when the purchase data is not found.

### 2. captureRequest: array values in ``
```
TypeError: urldecode(): Argument #1 () must be of type string, array given
```
PHP `` can contain arrays when query params use array notation 
(e.g. `platforms[]=sourcemod`). The `captureRequest()` function now handles both 
string and array values by mapping `urldecode` over each element.

### Tests added
- Unit test for `captureRequest()` with array `` values
- E2E test using `->get()` with the exact failing params from Sentry
- Test for missing `tid` returning 404 in PagePayment