### PR TITLE
Add demo guard to shop profile endpoint

### DIFF
--- a/includes/Http/Controllers/Api/Shop/UserProfileResource.php
+++ b/includes/Http/Controllers/Api/Shop/UserProfileResource.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Http\Controllers\Api\Shop;
 
+use App\Http\Responses\ApiResponse;
 use App\Http\Responses\SuccessApiResponse;
 use App\Http\Validation\Rules\FullNameRule;
 use App\Http\Validation\Rules\MaxLengthRule;
@@ -82,6 +83,10 @@ class UserProfileResource
                 $validated["billing_address_city"]
             )
         );
+
+        if (is_demo_user($user->getId())) {
+            return new ApiResponse("demo_mode", $lang->t("demo_mode"), false);
+        }
 
         $userRepository->update($user);
 

--- a/tests/Feature/Http/Api/Shop/UserProfileResourceTest.php
+++ b/tests/Feature/Http/Api/Shop/UserProfileResourceTest.php
@@ -14,6 +14,12 @@ class UserProfileResourceTest extends HttpTestCase
         $this->userRepository = $this->app->make(UserRepository::class);
     }
 
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        putenv("APP_SUBDOMAIN");
+    }
+
     /** @test */
     public function updates_profile()
     {
@@ -69,5 +75,39 @@ class UserProfileResourceTest extends HttpTestCase
             ],
             $json["warnings"]
         );
+    }
+
+    /** @test */
+    public function cannot_update_profile_as_admin_in_demo_mode()
+    {
+        putenv("APP_SUBDOMAIN=demo");
+        $admin = $this->userRepository->get(1);
+        $this->actingAs($admin);
+
+        $response = $this->put("/api/profile", [
+            "username" => "newname",
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $json = $this->decodeJsonResponse($response);
+        $this->assertSame("demo_mode", $json["return_id"]);
+    }
+
+    /** @test */
+    public function can_update_profile_in_demo_mode()
+    {
+        putenv("APP_SUBDOMAIN=demo");
+        $user = $this->factory->user();
+        $this->actingAs($user);
+
+        $response = $this->put("/api/profile", [
+            "username" => "newname",
+            "forename" => "newfn",
+            "surname" => "newln",
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $json = $this->decodeJsonResponse($response);
+        $this->assertSame("ok", $json["return_id"]);
     }
 }


### PR DESCRIPTION
Adds the missing `is_demo_user()` check to `UserProfileResource::put()` (`PUT /api/profile`), preventing admin user (ID 1) from editing their own username/profile on the demo shop.

Also adds two tests covering the blocked and allowed scenarios in demo mode.